### PR TITLE
Add CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,23 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        ruby-version: ['2.5', '2.6', '2.7']
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: ${{ matrix.ruby-version }}
+        bundler-cache: true # runs 'bundle install' and caches installed gems automatically
+    - name: Run tests
+      run: bundle exec rake


### PR DESCRIPTION
This pull request proposes the addition of a CI workflow for Ruby 2.5, 2.6, and 2.7.

Note that while the [README mentions support for Ruby 2.3 and 2.4](https://github.com/ginjo/omniauth-slack/blob/9d202912c6d45f1a2fc611159b21c98cef8164ca/README.md#omniauth-slack-a-ruby-gem), this pull request omits those versions due to them being EOL (https://www.ruby-lang.org/en/news/2020/04/05/support-of-ruby-2-4-has-ended/).