### PR TITLE
Send access_token_class as client option

### DIFF
--- a/lib/omniauth-slack/oauth2/client.rb
+++ b/lib/omniauth-slack/oauth2/client.rb
@@ -9,12 +9,12 @@ module OmniAuth
   module Slack
     module OAuth2
       class Client < ::OAuth2::Client
-        
+
         include OmniAuth::Slack::Debug
-        
+
         #using StringRefinements
         #using OAuth2Refinements
-        
+
         # If this is an array, request history will be stored.
         # Only store request history if each Client instance is relatively short-lived.
         #
@@ -33,9 +33,9 @@ module OmniAuth
         #
         HISTORY_DEFAULT=nil
         SUBDOMAIN_DEFAULT=nil
-      
+
         attr_accessor :logger, :history, :subdomain
-        
+
         def initialize(*args, **options)
           debug{"args: #{args}"}
           super
@@ -45,22 +45,22 @@ module OmniAuth
           self.history && self.history = self.history.dup
           self.subdomain ||= options[:subdomain] || SUBDOMAIN_DEFAULT
         end
-                
+
         # Wraps OAuth2::Client#get_token to pass in the omniauth-slack AccessToken class.
-        def get_token(params, access_token_opts = {}, access_token_class = OmniAuth::Slack::OAuth2::AccessToken) # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
+        def get_token(params, access_token_opts = {}) # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
           debug{"params #{params}, access_token_opts #{access_token_opts}"}
-          rslt = super(params, access_token_opts, access_token_class)
+          rslt = super(params, access_token_opts)
           debug{"Client #{self} built AccessToken #{rslt}"}
           rslt
         end
-        
+
         # Logs each API request and stores the API result in History array (if exists).
         #
         # Storage can be disabled by setting client_options: {history: false}.
         # Storage can be enabled by setting client_options: {history: Array.new}.
         # Storage is enabled by default, when client is created from Strategy.
-        # 
-        # 
+        #
+        #
         def request(*args)
           logger.debug "(slack) API request '#{args[0..1]}'."  # in thread '#{Thread.current.object_id}'."  # by Client '#{self}'
           debug{"API request args #{args}"}
@@ -88,7 +88,7 @@ module OmniAuth
             super
           end
         end
-        
+
       end
     end
   end

--- a/lib/omniauth/strategies/slack.rb
+++ b/lib/omniauth/strategies/slack.rb
@@ -9,9 +9,9 @@ require 'uri'
 
 module OmniAuth
   using Slack::OAuth2Refinements
-  
+
   module Strategies
-  
+
     # This is the OmniAuth strategy for Slack.
     # It is used as Rack middleware.
     #
@@ -20,34 +20,35 @@ module OmniAuth
     #     end
     #
     class Slack < OmniAuth::Strategies::OAuth2
-      include OmniAuth::Slack::Debug 
-      
-      
+      include OmniAuth::Slack::Debug
+
+
       ###  Options  ###
 
       # Master list of authorization options handled by omniauth-slack.
       # See below for redirect_uri.
-      # 
+      #
       AUTH_OPTIONS = %i(scope user_scope team team_domain)
-      
+
       debug{"#{self} setting up default options"}
-      
+
       # Default strategy name
       option :name, 'slack'
-      
+
       # Options that can be passed with provider authorization URL.
       option :authorize_options, AUTH_OPTIONS - %i(team_domain)
-      
+
       # OAuth2::Client options.
       option :client_options, {
-        site: 'https://slack.com',
-        authorize_url: '/oauth/v2/authorize',
-        token_url: '/api/oauth.v2.access',
+        access_token_class: OmniAuth::Slack::OAuth2::AccessToken,
         auth_scheme: :basic_auth,
-        raise_errors: false, # MUST be false to allow Slack's get-token response from v2 API.
+        authorize_url: '/oauth/v2/authorize',
         history: Array.new,
+        raise_errors: false, # MUST be false to allow Slack's get-token response from v2 API.
+        site: 'https://slack.com',
+        token_url: '/api/oauth.v2.access',
       }
-      
+
       # Authorization token-exchange API call options.
       option :auth_token_params, {
         mode: :query,
@@ -56,20 +57,20 @@ module OmniAuth
 
 
       ###  Omniauth Slack custom options  ###
-      
+
       # redirect_uri does not need to be in authorize_options,
       # since it inserted anyway by omniauth-oauth2 during both
       # the request (authorization) phase and the callback (get-token) phase.
       # The magic of redirect_uri actually happens in the callback_url method.
       option :redirect_uri
-      
+
       # Options allowed to pass from omniauth /auth/<provider> URL
       # to provider authorization URL.
       option :pass_through_params, %i(team)
-    
+
 
       ###  Data  ###
-      
+
       # User ID is not guaranteed to be globally unique across all Slack users.
       # The combination of user ID and team ID, on the other hand, is guaranteed
       # to be globally unique.
@@ -150,7 +151,7 @@ module OmniAuth
           session['omniauth.authorize_params'] = prms
         end
       end
-      
+
       # Pre-sets env vars for super.
       #
       # OmniAuth callback phase to extract session var for
@@ -162,7 +163,7 @@ module OmniAuth
         env['omniauth.authorize_params'] = session.delete('omniauth.authorize_params')
         super
       end
-      
+
       # Returns OmniAuth::Slack::AuthHash
       #
       # Super result is converted to plain hash first,
@@ -171,7 +172,7 @@ module OmniAuth
       def auth_hash
         OmniAuth::Slack::AuthHash.new super.to_hash
       end
-      
+
       # Uses `OmniAuth::Slack::OAuth2::Client` to handle Slack-specific features.
       #
       # * Logs API requests with OmniAuth.logger.
@@ -185,9 +186,9 @@ module OmniAuth
         @client ||= (
           team_domain = (pass_through_params.include?('team_domain') && request.params['team_domain']) ? request.params['team_domain'] : options.team_domain
           new_client = OmniAuth::Slack::OAuth2::Client.new(options.client_id, options.client_secret, deep_symbolize(options.client_options.merge({subdomain:team_domain})))
-  
+
           debug{"Strategy #{self} using Client #{new_client} with callback_url #{callback_url}"}
-          
+
           new_client
         )
       end
@@ -198,18 +199,18 @@ module OmniAuth
       def callback_url
         options.redirect_uri || full_host + script_name + callback_path
       end
-      
+
       ### Possibly obsolete
       #
       #   def user_id
       #     # access_token['user_id'] || access_token['user'].to_h['id'] || access_token['authorizing_user'].to_h['user_id']
       #     access_or_user_token&.user_id
       #   end
-      # 
+      #
       #   def team_id
       #     access_token&.team_id
       #   end
-      
+
       # Gets and decodes :pass_through_params option.
       #
       def pass_through_params
@@ -244,13 +245,13 @@ module OmniAuth
         debug{"Retrieved raw_info (size #{@raw_info.size}) (object_id #{@raw_info.object_id})"}
         @raw_info
       end
-      
+
       # Gets 'authed_user' sub-token from main access token.
       #
       def user_token
         access_token&.user_token
       end
-      
+
       # Gets main access_token, if valid, otherwise gets user_token, if valid.
       # Handles Slack v1 and v2 API (v2 is non-conformant with OAUTH2 spec).
       def access_or_user_token
@@ -262,14 +263,14 @@ module OmniAuth
           access_token
         end
       end
-      
+
       def scopes_requested
         # omniauth.authorize_params is an enhancement to omniauth functionality for omniauth-slack.
         out = {
           scope: env['omniauth.authorize_params'].to_h['scope'],
           user_scope: env['omniauth.authorize_params'].to_h['user_scope']
         }
-        
+
         debug{"scopes_requested: #{out}"}
         return out
       end


### PR DESCRIPTION
In order to adapt to the new code on Oauth2 gem we send the access_token_class as client param instead of sending it as param to get_token method

Fixes https://github.com/ginjo/omniauth-slack/issues/22